### PR TITLE
Removed invalid --user argument from pip uninstall

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,7 @@ You can also try an installing aws-sam-cli without `--user`
 .. code:: bash
 
     # Uninstall aws-sam-cli from the --user path
-    pip uninstall --user aws-sam-cli
+    pip uninstall aws-sam-cli
 
     pip install aws-sam-cli
 


### PR DESCRIPTION
There is no --user argument for the pip uninstall command e.g.

$ pip uninstall --user aws-sam-cli

Usage:   
  pip uninstall [options] <package> ...
  pip uninstall [options] -r <requirements file> ...

no such option: --user

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
